### PR TITLE
toc bump

### DIFF
--- a/Caravana.toc
+++ b/Caravana.toc
@@ -1,4 +1,4 @@
-## Interface: 90100
+## Interface: 100002
 ## Title: Caravana
 ## Author: Beviselynt
 ## Notes: Reminds you the location of your Vulpera camp.

--- a/caravana.lua
+++ b/caravana.lua
@@ -59,7 +59,7 @@ for k, v in pairs(events) do
     f:RegisterEvent(k)
 end
 
-GameTooltip:HookScript("OnTooltipSetSpell", function(self)
+TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Spell, function(self)
     local _, SpellID = self:GetSpell()
     if SpellID == 312372 and db.place then
         self:AddLine(atlasCamp .. " " .. db.place, 0.94, 0.9, 0.55, true)


### PR DESCRIPTION
toc bump
fixed tooltip errors

WoW Version 10.0.2 changed the way tooltips are handled, I fixed the problem and bumped the toc version.